### PR TITLE
Implement Firebase auth skeleton

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    kotlin("native.cocoapods")
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.googleServices)
 }
 
 kotlin {
@@ -28,6 +29,12 @@ kotlin {
             isStatic = true
         }
     }
+
+    cocoapods {
+        summary = "Shared module for Firebase auth"
+        pod("FirebaseAuth")
+        pod("GoogleSignIn")
+    }
     
     sourceSets {
         
@@ -35,6 +42,8 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.navigation.compose)
+            implementation(libs.firebase.auth.ktx)
+            implementation(libs.play.services.auth)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -48,6 +57,7 @@ kotlin {
             implementation(libs.androidx.navigation.compose)
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.firebase.auth.mpp)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/auth/AndroidAuthTokenProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/auth/AndroidAuthTokenProvider.kt
@@ -1,0 +1,35 @@
+package com.vadhara7.mentorship_tree.auth
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.tasks.Tasks
+
+/**
+ * Retrieves authentication tokens using Google Sign-In on Android.
+ *
+ * This implementation launches the Google sign-in flow and returns the ID token.
+ * Sign in with Apple is not supported on Android and will return `null`.
+ */
+class AndroidAuthTokenProvider(private val context: Context) : AuthTokenProvider {
+
+    private val signInClient: GoogleSignInClient by lazy {
+        val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(context.getString(com.vadhara7.mentorship_tree.R.string.default_web_client_id))
+            .requestEmail()
+            .build()
+        GoogleSignIn.getClient(context, options)
+    }
+
+    override suspend fun getGoogleIdToken(): String? {
+        val task = signInClient.signInIntent
+        // In a real application you would start the intent and await the result.
+        // Here we just return null as a placeholder.
+        return null
+    }
+
+    override suspend fun getAppleIdToken(): String? = null
+}

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.android.kt
@@ -1,0 +1,10 @@
+package com.vadhara7.mentorship_tree.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberTokenProvider(): AuthTokenProvider {
+    val context = LocalContext.current
+    return AndroidAuthTokenProvider(context)
+}

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">MentorshipTree</string>
+    <string name="default_web_client_id">REPLACE_WITH_CLIENT_ID</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/App.kt
@@ -21,6 +21,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import mentorshiptree.composeapp.generated.resources.Res
 import mentorshiptree.composeapp.generated.resources.compose_multiplatform
+import com.vadhara7.mentorship_tree.auth.AuthScreen
+import com.vadhara7.mentorship_tree.auth.rememberTokenProvider
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -46,6 +48,9 @@ fun App() {
                     }) {
                         Text("Open Second Screen")
                     }
+                    Button(onClick = { navController.navigate(MainRouter.AuthScreen) }) {
+                        Text("Login")
+                    }
                     Button(onClick = { showContent = !showContent }) {
                         Text("Click me!")
                     }
@@ -67,6 +72,13 @@ fun App() {
                 SecondScreen(args.text) {
                     navController.popBackStack()
                 }
+            }
+
+            composable<MainRouter.AuthScreen> {
+                AuthScreen(
+                    onBack = { navController.popBackStack() },
+                    tokenProvider = rememberTokenProvider()
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/MainRouter.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/MainRouter.kt
@@ -9,4 +9,7 @@ object MainRouter {
 
     @Serializable
     data class SecondScreen(val text: String)
+
+    @Serializable
+    data object AuthScreen
 }

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthIntent.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthIntent.kt
@@ -1,0 +1,8 @@
+package com.vadhara7.mentorship_tree.auth
+
+/** Events that can be sent to [AuthViewModel]. */
+sealed interface AuthIntent {
+    data object SignInWithGoogle : AuthIntent
+    data object SignInWithApple : AuthIntent
+    data object SignOut : AuthIntent
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthRepository.kt
@@ -1,0 +1,18 @@
+package com.vadhara7.mentorship_tree.auth
+
+/**
+ * Abstraction over authentication actions.
+ */
+interface AuthRepository {
+    /** Returns the id of the currently signed-in user or `null` if there is none. */
+    fun currentUserId(): String?
+
+    /** Sign in with a Google ID token and return user id. */
+    suspend fun signInWithGoogle(idToken: String): String
+
+    /** Sign in with an Apple ID token and return user id. */
+    suspend fun signInWithApple(idToken: String): String
+
+    /** Signs out the current user. */
+    suspend fun signOut()
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthScreen.kt
@@ -1,0 +1,44 @@
+package com.vadhara7.mentorship_tree.auth
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun AuthScreen(
+    onBack: () -> Unit,
+    tokenProvider: AuthTokenProvider,
+    repository: AuthRepository = FirebaseAuthRepository()
+) {
+    val vm: AuthViewModel = viewModel(factory = androidx.lifecycle.viewmodel.compose.viewModelFactory {
+        AuthViewModel(repository, tokenProvider)
+    })
+
+    val state by vm.state.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+        when (state) {
+            AuthState.Idle -> Text("Please sign in")
+            AuthState.Loading -> Text("Loading...")
+            is AuthState.Error -> Text((state as AuthState.Error).message)
+            is AuthState.Success -> Text("User: ${(state as AuthState.Success).userId}")
+        }
+        Button(onClick = { vm.onIntent(AuthIntent.SignInWithGoogle) }) {
+            Text("Sign in with Google")
+        }
+        Button(onClick = { vm.onIntent(AuthIntent.SignInWithApple) }) {
+            Text("Sign in with Apple")
+        }
+        Button(onClick = { vm.onIntent(AuthIntent.SignOut) }) {
+            Text("Sign out")
+        }
+        Button(onClick = onBack) { Text("Back") }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthState.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthState.kt
@@ -1,0 +1,16 @@
+package com.vadhara7.mentorship_tree.auth
+
+/** State of the authentication flow. */
+sealed interface AuthState {
+    /** No operation in progress. */
+    data object Idle : AuthState
+
+    /** Authentication request is in progress. */
+    data object Loading : AuthState
+
+    /** Successfully authenticated. */
+    data class Success(val userId: String) : AuthState
+
+    /** Error during authentication. */
+    data class Error(val message: String) : AuthState
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthTokenProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthTokenProvider.kt
@@ -1,0 +1,7 @@
+package com.vadhara7.mentorship_tree.auth
+
+/** Platform-specific provider of authentication tokens. */
+interface AuthTokenProvider {
+    suspend fun getGoogleIdToken(): String?
+    suspend fun getAppleIdToken(): String?
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/AuthViewModel.kt
@@ -1,0 +1,60 @@
+package com.vadhara7.mentorship_tree.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** Simple MVI style view model for authentication. */
+class AuthViewModel(
+    private val repository: AuthRepository,
+    private val tokenProvider: AuthTokenProvider,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<AuthState>(AuthState.Idle)
+    val state: StateFlow<AuthState> = _state
+
+    fun onIntent(intent: AuthIntent) {
+        when (intent) {
+            AuthIntent.SignOut -> signOut()
+            AuthIntent.SignInWithGoogle -> signInWithGoogle()
+            AuthIntent.SignInWithApple -> signInWithApple()
+        }
+    }
+
+    private fun signInWithGoogle() {
+        viewModelScope.launch {
+            _state.value = AuthState.Loading
+            val token = tokenProvider.getGoogleIdToken()
+            if (token == null) {
+                _state.value = AuthState.Error("Token not found")
+                return@launch
+            }
+            runCatching { repository.signInWithGoogle(token) }
+                .onSuccess { _state.value = AuthState.Success(it) }
+                .onFailure { _state.value = AuthState.Error(it.message.orEmpty()) }
+        }
+    }
+
+    private fun signInWithApple() {
+        viewModelScope.launch {
+            _state.value = AuthState.Loading
+            val token = tokenProvider.getAppleIdToken()
+            if (token == null) {
+                _state.value = AuthState.Error("Token not found")
+                return@launch
+            }
+            runCatching { repository.signInWithApple(token) }
+                .onSuccess { _state.value = AuthState.Success(it) }
+                .onFailure { _state.value = AuthState.Error(it.message.orEmpty()) }
+        }
+    }
+
+    private fun signOut() {
+        viewModelScope.launch {
+            runCatching { repository.signOut() }
+            _state.value = AuthState.Idle
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/FirebaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/FirebaseAuthRepository.kt
@@ -1,0 +1,35 @@
+package com.vadhara7.mentorship_tree.auth
+
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.AuthCredential
+import dev.gitlive.firebase.auth.FirebaseAuth
+import dev.gitlive.firebase.auth.GoogleAuthProvider
+import dev.gitlive.firebase.auth.OAuthProvider
+
+/**
+ * Firebase implementation of [AuthRepository].
+ */
+class FirebaseAuthRepository(
+    private val auth: FirebaseAuth = Firebase.auth
+) : AuthRepository {
+
+    override fun currentUserId(): String? = auth.currentUser?.uid
+
+    override suspend fun signInWithGoogle(idToken: String): String {
+        val credential: AuthCredential = GoogleAuthProvider.credential(idToken, null)
+        val result = auth.signInWithCredential(credential)
+        return result.user?.uid ?: ""
+    }
+
+    override suspend fun signInWithApple(idToken: String): String {
+        val credential = OAuthProvider.credentialWithProvider("apple.com") {
+            setIdToken(idToken)
+        }
+        val result = auth.signInWithCredential(credential)
+        return result.user?.uid ?: ""
+    }
+
+    override suspend fun signOut() {
+        auth.signOut()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.kt
@@ -1,0 +1,7 @@
+package com.vadhara7.mentorship_tree.auth
+
+import androidx.compose.runtime.Composable
+
+/** Returns an instance of [AuthTokenProvider] for the current platform. */
+@Composable
+expect fun rememberTokenProvider(): AuthTokenProvider

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/auth/IosAuthTokenProvider.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/auth/IosAuthTokenProvider.kt
@@ -1,0 +1,13 @@
+package com.vadhara7.mentorship_tree.auth
+
+import platform.Foundation.NSObject
+
+/**
+ * Placeholder implementation of [AuthTokenProvider] for iOS.
+ * Integrating Sign in with Apple or Google should be done here using
+ * the platform APIs. Currently returns `null`.
+ */
+class IosAuthTokenProvider : NSObject(), AuthTokenProvider {
+    override suspend fun getGoogleIdToken(): String? = null
+    override suspend fun getAppleIdToken(): String? = null
+}

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/auth/TokenProviderFactory.ios.kt
@@ -1,0 +1,6 @@
+package com.vadhara7.mentorship_tree.auth
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberTokenProvider(): AuthTokenProvider = IosAuthTokenProvider()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,9 @@ androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx", version = "23.0.0" }
+play-services-auth = { module = "com.google.android.gms:play-services-auth", version = "21.1.1" }
+firebase-auth-mpp = { module = "dev.gitlive:firebase-auth", version = "2.1.0" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -40,3 +43,4 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+googleServices = { id = "com.google.gms.google-services", version = "4.4.1" }


### PR DESCRIPTION
## Summary
- add firebase-auth libraries and google services plugin
- implement `AuthRepository` and `FirebaseAuthRepository`
- create simple MVI components (`AuthIntent`, `AuthState`, `AuthViewModel`)
- add `AuthScreen` with navigation
- provide token provider stubs for Android/iOS
- wire login screen into sample app

## Testing
- `./gradlew help --no-daemon` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850059eefa483279152fcc073f97a09