### PR TITLE
Add QR screen for mentee invitations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -67,6 +67,7 @@ kotlin {
                 implementation(libs.koin.compose.viewmodel)
                 implementation(libs.koin.compose.viewmodel.navigation)
                 implementation(libs.kotlinx.datetime)
+                implementation(libs.qrose)
             }
 
         }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="notifications">Notifications</string>
     <string name="add_mentor">Add mentor</string>
     <string name="add_mentee">Add mentee</string>
+    <string name="my_qr_instruction">Ask your mentee to scan this code to connect with you.</string>
     <string name="email">Email</string>
     <string name="send_request">Send request</string>
     <string name="cancel">Cancel</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="tree">Tree</string>
     <string name="notifications">Notifications</string>
     <string name="add_mentor">Add mentor</string>
+    <string name="add_mentee">Add mentee</string>
     <string name="email">Email</string>
     <string name="send_request">Send request</string>
     <string name="cancel">Cancel</string>

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/MainRouter.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/MainRouter.kt
@@ -29,6 +29,9 @@ object MainRouter {
 
     @Serializable
     data object AddMentorScreen
+
+    @Serializable
+    data object MyQrScreen
 }
 
 

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
@@ -29,6 +29,7 @@ import com.vadhara7.mentorship_tree.presentation.addMentor.ui.AddMentorScreen
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorEvent
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorIntent
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorViewModel
+import com.vadhara7.mentorship_tree.presentation.addMentee.ui.MyQrScreen
 import com.vadhara7.mentorship_tree.presentation.auth.ui.AuthScreen
 import com.vadhara7.mentorship_tree.presentation.auth.vm.AuthEvent
 import com.vadhara7.mentorship_tree.presentation.auth.vm.AuthViewModel
@@ -82,7 +83,8 @@ fun NavGraph(modifier: Modifier = Modifier) {
     val hiddenRoutes = remember {
         setOf(
             MainRouter.AuthScreen::class.qualifiedName,
-            MainRouter.AddMentorScreen::class.qualifiedName
+            MainRouter.AddMentorScreen::class.qualifiedName,
+            MainRouter.MyQrScreen::class.qualifiedName
         )
     }
 
@@ -212,6 +214,7 @@ fun NavGraph(modifier: Modifier = Modifier) {
                             viewModel.process(intent)
                             when (intent) {
                                 is TreeIntent.OnAddMentorClick -> navController.navigate(MainRouter.AddMentorScreen)
+                                is TreeIntent.OnAddMenteeClick -> navController.navigate(MainRouter.MyQrScreen)
                                 else -> {}
                             }
                         },
@@ -283,6 +286,10 @@ fun NavGraph(modifier: Modifier = Modifier) {
                         },
                         state = state.value
                     )
+                }
+
+                composable<MainRouter.MyQrScreen> {
+                    MyQrScreen(modifier = Modifier.padding(paddingValues))
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
@@ -22,43 +22,42 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import co.touchlab.kermit.Logger
 import com.vadhara7.mentorship_tree.core.mvi.ObserveAsEvents
 import com.vadhara7.mentorship_tree.domain.model.dto.RelationType
+import com.vadhara7.mentorship_tree.presentation.addMentee.ui.MyQrScreen
 import com.vadhara7.mentorship_tree.presentation.addMentor.ui.AddMentorScreen
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorEvent
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorIntent
 import com.vadhara7.mentorship_tree.presentation.addMentor.vm.AddMentorViewModel
-import com.vadhara7.mentorship_tree.presentation.addMentee.ui.MyQrScreen
 import com.vadhara7.mentorship_tree.presentation.auth.ui.AuthScreen
 import com.vadhara7.mentorship_tree.presentation.auth.vm.AuthEvent
 import com.vadhara7.mentorship_tree.presentation.auth.vm.AuthViewModel
-import com.vadhara7.mentorship_tree.presentation.tree.ui.TreeScreen
-import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeIntent
-import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeViewModel
 import com.vadhara7.mentorship_tree.presentation.notification.ui.NotificationScreen
-import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationViewModel
 import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationEvent
 import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationIntent
+import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationViewModel
 import com.vadhara7.mentorship_tree.presentation.snackbars.ProvideSnackbarController
+import com.vadhara7.mentorship_tree.presentation.tree.ui.TreeScreen
 import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeEvent
+import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeIntent
+import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeViewModel
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import mentorshiptree.composeapp.generated.resources.Res
 import mentorshiptree.composeapp.generated.resources.cancel
 import mentorshiptree.composeapp.generated.resources.failed_deletion
-import mentorshiptree.composeapp.generated.resources.try_delete_again
 import mentorshiptree.composeapp.generated.resources.failed_restoration
-import mentorshiptree.composeapp.generated.resources.try_restore_again
-import mentorshiptree.composeapp.generated.resources.send_request_to_restore
-import mentorshiptree.composeapp.generated.resources.restore_relation
-import mentorshiptree.composeapp.generated.resources.success_deletion
 import mentorshiptree.composeapp.generated.resources.failed_send_request
-import mentorshiptree.composeapp.generated.resources.request_accepted
 import mentorshiptree.composeapp.generated.resources.request_accept_failed
-import mentorshiptree.composeapp.generated.resources.request_declined
+import mentorshiptree.composeapp.generated.resources.request_accepted
 import mentorshiptree.composeapp.generated.resources.request_decline_failed
+import mentorshiptree.composeapp.generated.resources.request_declined
+import mentorshiptree.composeapp.generated.resources.restore_relation
 import mentorshiptree.composeapp.generated.resources.send_request
+import mentorshiptree.composeapp.generated.resources.send_request_to_restore
+import mentorshiptree.composeapp.generated.resources.success_deletion
+import mentorshiptree.composeapp.generated.resources.try_delete_again
+import mentorshiptree.composeapp.generated.resources.try_restore_again
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -237,15 +236,34 @@ fun NavGraph(modifier: Modifier = Modifier) {
                             is NotificationEvent.ShowAcceptSuccess -> snackbarController.showAsync(
                                 message = txtRequestAccepted,
                                 actionLabel = txtCancel,
-                                onAction = { viewModel.process(NotificationIntent.RestoreRequest(event.userId)) }
+                                onAction = {
+                                    viewModel.process(
+                                        NotificationIntent.RestoreRequest(
+                                            event.userId
+                                        )
+                                    )
+                                }
                             )
-                            NotificationEvent.ShowAcceptFailure -> snackbarController.showAsync(message = txtRequestAcceptFailed)
+
+                            NotificationEvent.ShowAcceptFailure -> snackbarController.showAsync(
+                                message = txtRequestAcceptFailed
+                            )
+
                             is NotificationEvent.ShowDeclineSuccess -> snackbarController.showAsync(
                                 message = txtRequestDeclined,
                                 actionLabel = txtCancel,
-                                onAction = { viewModel.process(NotificationIntent.RestoreRequest(event.userId)) }
+                                onAction = {
+                                    viewModel.process(
+                                        NotificationIntent.RestoreRequest(
+                                            event.userId
+                                        )
+                                    )
+                                }
                             )
-                            NotificationEvent.ShowDeclineFailure -> snackbarController.showAsync(message = txtRequestDeclineFailed)
+
+                            NotificationEvent.ShowDeclineFailure -> snackbarController.showAsync(
+                                message = txtRequestDeclineFailed
+                            )
                         }
                     }
 
@@ -289,7 +307,10 @@ fun NavGraph(modifier: Modifier = Modifier) {
                 }
 
                 composable<MainRouter.MyQrScreen> {
-                    MyQrScreen(modifier = Modifier.padding(paddingValues))
+                    MyQrScreen(
+                        modifier = Modifier,
+                        onCloseClick = { navController.customPopBackStack() }
+                    )
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
@@ -3,45 +3,71 @@ package com.vadhara7.mentorship_tree.presentation.addMentee.ui
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
-import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import io.github.alexzhirkevich.qrose.options.QrBrush
+import io.github.alexzhirkevich.qrose.options.solid
+import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import mentorshiptree.composeapp.generated.resources.Res
+import mentorshiptree.composeapp.generated.resources.ic_close
 import mentorshiptree.composeapp.generated.resources.my_qr_instruction
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun MyQrScreen(modifier: Modifier = Modifier) {
+fun MyQrScreen(modifier: Modifier = Modifier, onCloseClick: () -> Unit) {
     val user = Firebase.auth.currentUser
-    val data = user?.email ?: user?.uid.orEmpty()
+    val data by remember { mutableStateOf(user?.email ?: user?.uid.orEmpty()) }
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
 
     Surface(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .systemBarsPadding(),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+                .systemBarsPadding()
+                .padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
         ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.Top
+            ) {
+                IconButton(onClick = onCloseClick) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_close),
+                        contentDescription = "Back",
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
             if (data.isNotEmpty()) {
                 Image(
                     painter = rememberQrCodePainter(data) {
                         colors {
-                            dark = QrBrush.solid(MaterialTheme.colorScheme.onSurface)
+                            dark = QrBrush.solid(onSurfaceColor)
                         }
                     },
                     contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
@@ -1,0 +1,36 @@
+package com.vadhara7.mentorship_tree.presentation.addMentee.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.auth
+import io.github.alexzhirkevich.qrose.rememberQrCodePainter
+
+@Composable
+fun MyQrScreen(modifier: Modifier = Modifier) {
+    val user = Firebase.auth.currentUser
+    val data = user?.email ?: user?.uid.orEmpty()
+
+    Surface(modifier = modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier.fillMaxSize().systemBarsPadding(),
+            contentAlignment = Alignment.Center
+        ) {
+            if (data.isNotEmpty()) {
+                Image(
+                    painter = rememberQrCodePainter(data),
+                    contentDescription = null,
+                    modifier = Modifier.size(240.dp)
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentee/ui/MyQrScreen.kt
@@ -1,18 +1,28 @@
 package com.vadhara7.mentorship_tree.presentation.addMentee.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import io.github.alexzhirkevich.qrose.rememberQrCodePainter
+import io.github.alexzhirkevich.qrose.options.QrBrush
+import mentorshiptree.composeapp.generated.resources.Res
+import mentorshiptree.composeapp.generated.resources.my_qr_instruction
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MyQrScreen(modifier: Modifier = Modifier) {
@@ -20,15 +30,29 @@ fun MyQrScreen(modifier: Modifier = Modifier) {
     val data = user?.email ?: user?.uid.orEmpty()
 
     Surface(modifier = modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier.fillMaxSize().systemBarsPadding(),
-            contentAlignment = Alignment.Center
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (data.isNotEmpty()) {
                 Image(
-                    painter = rememberQrCodePainter(data),
+                    painter = rememberQrCodePainter(data) {
+                        colors {
+                            dark = QrBrush.solid(MaterialTheme.colorScheme.onSurface)
+                        }
+                    },
                     contentDescription = null,
                     modifier = Modifier.size(240.dp)
+                )
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = stringResource(Res.string.my_qr_instruction),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 32.dp)
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/ui/TreeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/ui/TreeScreen.kt
@@ -39,6 +39,7 @@ import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeIntent
 import com.vadhara7.mentorship_tree.presentation.tree.vm.TreeState
 import mentorshiptree.composeapp.generated.resources.Res
 import mentorshiptree.composeapp.generated.resources.add_mentor
+import mentorshiptree.composeapp.generated.resources.add_mentee
 import mentorshiptree.composeapp.generated.resources.delete
 import mentorshiptree.composeapp.generated.resources.you
 import org.jetbrains.compose.resources.stringResource
@@ -56,6 +57,9 @@ fun TreeScreen(modifier: Modifier = Modifier, onIntent: (TreeIntent) -> Unit, st
             onAddMentorClick = {
                 onIntent(TreeIntent.OnAddMentorClick)
             },
+            onAddMenteeClick = {
+                onIntent(TreeIntent.OnAddMenteeClick)
+            },
             onDeleteNode = { node ->
                 onIntent(TreeIntent.OnDeleteRelation(node))
             }
@@ -70,6 +74,7 @@ fun Tree(
     centerLabel: String? = null,
     mentorshipTree: MentorshipTree,
     onAddMentorClick: () -> Unit = {},
+    onAddMenteeClick: () -> Unit = {},
     onDeleteNode: (RelationNode) -> Unit = {},
 ) {
     // We measure everything in root coords, then convert to this Box coords
@@ -128,6 +133,15 @@ fun Tree(
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            LevelRow(
+                nodes = emptyList(),
+                onMeasured = { _, _ -> },
+                onDeleteNode = onDeleteNode,
+                showAddChip = true,
+                addLabel = stringResource(Res.string.add_mentee),
+                onAddClick = onAddMenteeClick
+            )
+
             // Mentees (all generations). Show first generation (closest to center) just above the center.
             for (i in menteeLevels.lastIndex downTo 0) {
                 LevelRow(

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/vm/TreeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/vm/TreeState.kt
@@ -20,6 +20,7 @@ data class TreeState(
 sealed interface TreeIntent : Intent {
     data object Init : TreeIntent
     data object OnAddMentorClick : TreeIntent
+    data object OnAddMenteeClick : TreeIntent
     data class OnDeleteRelation(val relation: RelationNode) : TreeIntent
     data class OnRestoreRelation(val relation: RelationNode) : TreeIntent
     data class OnSendRestoreRequest(val relation: RelationNode) : TreeIntent

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/vm/TreeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/tree/vm/TreeViewModel.kt
@@ -62,6 +62,10 @@ class TreeProcessor(
                 // handle in NavGraph
             }
 
+            is TreeIntent.OnAddMenteeClick -> flow {
+                // handle in NavGraph
+            }
+
             is TreeIntent.OnDeleteRelation -> flow {
                 Logger.i("TreeIntent.OnDeleteRelation")
                 val response = relationsRepository.deleteRelation(intent.relation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ googleGmsGoogleServices = "4.4.2"
 googleFirebaseCrashlytics = "3.0.4"
 firebase-gitlive-sdk = "2.1.0"
 firebase-bom = "33.15.0"
+qrose = "1.0.1"
 
 [libraries]
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -54,6 +55,7 @@ gitlive-firebase-kotlin-crashlytics = { module = "dev.gitlive:firebase-crashlyti
 gitlive-firebase-kotlin-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = "firebase-gitlive-sdk" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
+qrose = { module = "io.github.alexzhirkevich:qrose", version.ref = "qrose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add `OnAddMenteeClick` intent and top-level add mentee chip
- show QR code of current user for mentee invites
- route to QR screen from tree screen

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a472c0f1548327b92aa1d79ec6e6db