### PR TITLE
Handle camera permission for QR scanning

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
 
     <application

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/AndroidApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/AndroidApp.kt
@@ -2,6 +2,7 @@ package com.vadhara7.mentorship_tree
 
 import android.app.Application
 import com.vadhara7.mentorship_tree.core.di.commonModule
+import com.vadhara7.mentorship_tree.core.di.permissionModule
 import com.vadhara7.mentorship_tree.core.di.qrScannerModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -18,7 +19,7 @@ class AndroidApp : Application() {
         startKoin {
             androidContext(this@AndroidApp)
             androidLogger()
-            modules(commonModule, qrScannerModule)
+            modules(commonModule, qrScannerModule, permissionModule)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/core/di/PermissionModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/core/di/PermissionModule.kt
@@ -1,0 +1,10 @@
+package com.vadhara7.mentorship_tree.core.di
+
+import com.vadhara7.mentorship_tree.data.repository.AndroidPermissionRepository
+import com.vadhara7.mentorship_tree.domain.repository.PermissionRepository
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+val permissionModule = module {
+    single<PermissionRepository> { AndroidPermissionRepository(androidContext()) }
+}

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/data/repository/AndroidPermissionRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/data/repository/AndroidPermissionRepository.kt
@@ -1,0 +1,17 @@
+package com.vadhara7.mentorship_tree.data.repository
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.vadhara7.mentorship_tree.domain.repository.PermissionRepository
+
+class AndroidPermissionRepository(
+    private val context: Context
+) : PermissionRepository {
+    override fun hasCameraPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/data/repository/AndroidQrScannerRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/data/repository/AndroidQrScannerRepository.kt
@@ -1,6 +1,7 @@
 package com.vadhara7.mentorship_tree.data.repository
 
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
@@ -25,6 +26,15 @@ class AndroidQrScannerRepository(
 ) : QrScannerRepository {
 
     override suspend fun scan(): String? = suspendCancellableCoroutine { cont ->
+        if (ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.CAMERA
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            cont.resume(null)
+            return@suspendCancellableCoroutine
+        }
+
         val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
         val executor = ContextCompat.getMainExecutor(context)
         cameraProviderFuture.addListener({

--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
@@ -1,0 +1,5 @@
+package com.vadhara7.mentorship_tree.domain.repository
+
+actual interface PermissionRepository {
+    actual fun hasCameraPermission(): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
@@ -1,0 +1,5 @@
+package com.vadhara7.mentorship_tree.domain.repository
+
+expect interface PermissionRepository {
+    fun hasCameraPermission(): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/QrScannerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/QrScannerScreen.kt
@@ -14,6 +14,10 @@ fun QrScannerScreen(
     onIntent: (QrScannerIntent) -> Unit
 ) {
     LaunchedEffect(Unit) { onIntent(QrScannerIntent.StartScanning) }
-    Text(text = state.result ?: "Scanning...", modifier = modifier)
+    if (state.hasPermission) {
+        Text(text = state.result ?: "Scanning...", modifier = modifier)
+    } else {
+        Text(text = "Camera permission required", modifier = modifier)
+    }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/vm/QrScannerState.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/vm/QrScannerState.kt
@@ -3,7 +3,8 @@ package com.vadhara7.mentorship_tree.presentation.qrScanner.vm
 import com.vadhara7.mentorship_tree.core.mvi.*
 
 data class QrScannerState(
-    val result: String? = null
+    val result: String? = null,
+    val hasPermission: Boolean = true
 ) : State
 
 sealed interface QrScannerIntent : Intent {
@@ -12,9 +13,11 @@ sealed interface QrScannerIntent : Intent {
 
 sealed interface QrScannerEffect : Effect {
     data class OnResult(val text: String?) : QrScannerEffect
+    data object PermissionDenied : QrScannerEffect
 }
 
 sealed interface QrScannerEvent : Event {
     data class OnScanned(val text: String) : QrScannerEvent
+    data object OnPermissionDenied : QrScannerEvent
 }
 

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/vm/QrScannerViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/vm/QrScannerViewModel.kt
@@ -1,6 +1,7 @@
 package com.vadhara7.mentorship_tree.presentation.qrScanner.vm
 
 import com.vadhara7.mentorship_tree.core.mvi.*
+import com.vadhara7.mentorship_tree.domain.repository.PermissionRepository
 import com.vadhara7.mentorship_tree.domain.repository.QrScannerRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -17,13 +18,18 @@ class QrScannerViewModel(
 )
 
 class QrScannerProcessor(
-    private val repository: QrScannerRepository
+    private val repository: QrScannerRepository,
+    private val permissionRepository: PermissionRepository
 ) : Processor<QrScannerIntent, QrScannerEffect, QrScannerState> {
     override fun process(intent: QrScannerIntent, state: QrScannerState): Flow<QrScannerEffect> {
         return when (intent) {
             QrScannerIntent.StartScanning -> flow {
-                val text = repository.scan()
-                emit(QrScannerEffect.OnResult(text))
+                if (permissionRepository.hasCameraPermission()) {
+                    val text = repository.scan()
+                    emit(QrScannerEffect.OnResult(text))
+                } else {
+                    emit(QrScannerEffect.PermissionDenied)
+                }
             }
         }
     }
@@ -33,6 +39,7 @@ class QrScannerReducer : Reducer<QrScannerEffect, QrScannerState> {
     override fun reduce(effect: QrScannerEffect, state: QrScannerState): QrScannerState {
         return when (effect) {
             is QrScannerEffect.OnResult -> state.copy(result = effect.text)
+            QrScannerEffect.PermissionDenied -> state.copy(hasPermission = false)
         }
     }
 }
@@ -41,6 +48,7 @@ class QrScannerPublisher : Publisher<QrScannerEffect, QrScannerEvent> {
     override fun publish(effect: QrScannerEffect): QrScannerEvent? {
         return when (effect) {
             is QrScannerEffect.OnResult -> effect.text?.let { QrScannerEvent.OnScanned(it) }
+            QrScannerEffect.PermissionDenied -> QrScannerEvent.OnPermissionDenied
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/MainViewController.kt
@@ -2,6 +2,7 @@ package com.vadhara7.mentorship_tree
 
 import androidx.compose.ui.window.ComposeUIViewController
 import com.vadhara7.mentorship_tree.core.di.commonModule
+import com.vadhara7.mentorship_tree.core.di.permissionModule
 import com.vadhara7.mentorship_tree.core.di.qrScannerModule
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.crashlytics.crashlytics
@@ -15,7 +16,7 @@ fun initialize() {
     Firebase.crashlytics.setCrashlyticsCollectionEnabled(true)
 
     startKoin {
-        modules(commonModule, qrScannerModule)
+        modules(commonModule, qrScannerModule, permissionModule)
     }
 
 }

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/core/di/PermissionModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/core/di/PermissionModule.kt
@@ -1,0 +1,9 @@
+package com.vadhara7.mentorship_tree.core.di
+
+import com.vadhara7.mentorship_tree.data.repository.IosPermissionRepository
+import com.vadhara7.mentorship_tree.domain.repository.PermissionRepository
+import org.koin.dsl.module
+
+val permissionModule = module {
+    single<PermissionRepository> { IosPermissionRepository() }
+}

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/data/repository/IosPermissionRepository.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/data/repository/IosPermissionRepository.kt
@@ -1,0 +1,7 @@
+package com.vadhara7.mentorship_tree.data.repository
+
+import com.vadhara7.mentorship_tree.domain.repository.PermissionRepository
+
+class IosPermissionRepository : PermissionRepository {
+    override fun hasCameraPermission(): Boolean = true
+}

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/domain/repository/PermissionRepository.kt
@@ -1,0 +1,5 @@
+package com.vadhara7.mentorship_tree.domain.repository
+
+actual interface PermissionRepository {
+    actual fun hasCameraPermission(): Boolean
+}


### PR DESCRIPTION
## Summary
- add camera permission in Android manifest
- introduce cross-platform PermissionRepository and DI modules
- guard QR scanner flow and UI when permission is missing

## Testing
- No tests were run due to user request to avoid Gradle builds

------
https://chatgpt.com/codex/tasks/task_e_68a46a9bd72483279386ff6129fd6269