### PR TITLE
Wire QR scan result into AddMentor flow

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/CameraPreview.kt
+++ b/composeApp/src/androidMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/CameraPreview.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import com.vadhara7.mentorship_tree.domain.repository.QrScannerRepository
 import com.vadhara7.mentorship_tree.data.repository.AndroidQrScannerRepository
 import org.koin.compose.koinInject
 
@@ -15,7 +14,7 @@ import org.koin.compose.koinInject
 actual fun CameraPreview(modifier: Modifier, onPreviewReady: () -> Unit) {
     val context = LocalContext.current
     val previewView = remember { PreviewView(context) }
-    val repository = koinInject<QrScannerRepository>() as AndroidQrScannerRepository
+    val repository: AndroidQrScannerRepository = koinInject()
 
     AndroidView(factory = { previewView }, modifier = modifier)
 

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/navigation/NavGraph.kt
@@ -22,7 +22,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.toRoute
 import com.vadhara7.mentorship_tree.core.mvi.ObserveAsEvents
 import com.vadhara7.mentorship_tree.domain.model.dto.RelationType
 import com.vadhara7.mentorship_tree.presentation.addMentee.ui.MyQrScreen
@@ -38,6 +37,7 @@ import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationEve
 import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationIntent
 import com.vadhara7.mentorship_tree.presentation.notification.vm.NotificationViewModel
 import com.vadhara7.mentorship_tree.presentation.qrScanner.ui.QrScannerScreen
+import com.vadhara7.mentorship_tree.presentation.qrScanner.vm.QrScannerEvent
 import com.vadhara7.mentorship_tree.presentation.qrScanner.vm.QrScannerViewModel
 import com.vadhara7.mentorship_tree.presentation.snackbars.ProvideSnackbarController
 import com.vadhara7.mentorship_tree.presentation.tree.ui.TreeScreen
@@ -64,7 +64,6 @@ import mentorshiptree.composeapp.generated.resources.try_restore_again
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
-import org.koin.core.parameter.parametersOf
 
 
 fun NavController.customPopBackStack() {
@@ -281,7 +280,6 @@ fun NavGraph(modifier: Modifier = Modifier) {
                 }
 
                 composable<MainRouter.AddMentorScreen> {
-                    val args = it.toRoute<MainRouter.AddMentorScreen>()
                     val viewModel = koinViewModel<AddMentorViewModel>(viewModelStoreOwner = it)
                     val state = viewModel.state.collectAsStateWithLifecycle(it)
 
@@ -317,6 +315,17 @@ fun NavGraph(modifier: Modifier = Modifier) {
                 composable<MainRouter.QrScannerScreen> {
                     val viewModel = koinViewModel<QrScannerViewModel>(viewModelStoreOwner = it)
                     val state = viewModel.state.collectAsStateWithLifecycle(it)
+                    ObserveAsEvents(viewModel.event) { event ->
+                        when (event) {
+                            is QrScannerEvent.OnScanned -> navController.navigate(
+                                MainRouter.AddMentorScreen(initialEmail = event.text)
+                            ) {
+                                popUpTo<MainRouter.AddMentorScreen>(inclusive = true)
+                            }
+                            QrScannerEvent.OnPermissionDenied ->
+                                navController.customPopBackStack()
+                        }
+                    }
 
                     QrScannerScreen(
                         modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentor/vm/AddMentorViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/vadhara7/mentorship_tree/presentation/addMentor/vm/AddMentorViewModel.kt
@@ -5,10 +5,13 @@ import com.vadhara7.mentorship_tree.domain.repository.RelationsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
+import androidx.lifecycle.SavedStateHandle
+
 class AddMentorViewModel(
     processor: AddMentorProcessor,
     reducer: AddMentorReducer,
-    publisher: AddMentorPublisher
+    publisher: AddMentorPublisher,
+    savedStateHandle: SavedStateHandle,
 ) : MviViewModel<AddMentorIntent, AddMentorEffect, AddMentorEvent, AddMentorState>(
     defaultState = AddMentorState(),
     processor = processor,
@@ -16,7 +19,9 @@ class AddMentorViewModel(
     publisher = publisher
 ) {
     init {
-//        initialEmail?.let { process(AddMentorIntent.OnEmailInput(it)) }
+        savedStateHandle.get<String?>("initialEmail")?.let {
+            process(AddMentorIntent.OnEmailInput(it))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hook up Android CameraPreview to repository
- prefill AddMentor email from navigation arguments
- navigate to AddMentor when QR scan returns an email

## Testing
- `./gradlew :composeApp:build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c174fea48327a0079dec6e527209