### PR TITLE
feat: add iOS camera preview

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/data/repository/IosQrScannerRepository.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/data/repository/IosQrScannerRepository.kt
@@ -3,23 +3,40 @@ package com.vadhara7.mentorship_tree.data.repository
 import com.vadhara7.mentorship_tree.domain.repository.QrScannerRepository
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.suspendCancellableCoroutine
-import platform.AVFoundation.*
+import platform.AVFoundation.AVMediaTypeVideo
+import platform.AVFoundation.AVMetadataMachineReadableCodeObject
+import platform.AVFoundation.AVMetadataObjectTypeQRCode
+import platform.AVFoundation.AVMetadataOutput
+import platform.AVFoundation.AVCaptureConnection
+import platform.AVFoundation.AVCaptureDevice
+import platform.AVFoundation.AVCaptureDeviceInput
+import platform.AVFoundation.AVCaptureMetadataOutput
+import platform.AVFoundation.AVCaptureOutput
+import platform.AVFoundation.AVCaptureSession
 import platform.darwin.NSObject
 import platform.darwin.dispatch_get_main_queue
 import kotlin.coroutines.resume
 
 class IosQrScannerRepository : QrScannerRepository {
+
+    @OptIn(ExperimentalForeignApi::class)
+    val session: AVCaptureSession = AVCaptureSession()
+
     @OptIn(ExperimentalForeignApi::class)
     override suspend fun scan(): String? = suspendCancellableCoroutine { cont ->
-        val session = AVCaptureSession()
         val device = AVCaptureDevice.defaultDeviceWithMediaType(AVMediaTypeVideo) ?: run {
             cont.resume(null)
             return@suspendCancellableCoroutine
         }
-        val input = AVCaptureDeviceInput(device, error = null)
-        if (session.canAddInput(input)) session.addInput(input)
-        val output = AVCaptureMetadataOutput()
-        if (session.canAddOutput(output)) session.addOutput(output)
+
+        if (session.inputs.isEmpty()) {
+            val input = AVCaptureDeviceInput(device, error = null)
+            if (session.canAddInput(input)) session.addInput(input)
+        }
+
+        val output = session.outputs.firstOrNull { it is AVCaptureMetadataOutput } as? AVCaptureMetadataOutput
+            ?: AVCaptureMetadataOutput().also { if (session.canAddOutput(it)) session.addOutput(it) }
+
         val delegate = object : NSObject(), AVCaptureMetadataOutputObjectsDelegateProtocol {
             override fun captureOutput(
                 output: AVCaptureOutput,

--- a/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/CameraPreview.kt
+++ b/composeApp/src/iosMain/kotlin/com/vadhara7/mentorship_tree/presentation/qrScanner/ui/CameraPreview.kt
@@ -1,17 +1,36 @@
 package com.vadhara7.mentorship_tree.presentation.qrScanner.ui
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import com.vadhara7.mentorship_tree.data.repository.IosQrScannerRepository
+import com.vadhara7.mentorship_tree.domain.repository.QrScannerRepository
+import org.koin.compose.koinInject
+import platform.AVFoundation.AVCaptureVideoPreviewLayer
+import platform.AVFoundation.AVLayerVideoGravityResizeAspectFill
+import platform.UIKit.UIView
+import kotlinx.cinterop.ExperimentalForeignApi
 
+@OptIn(ExperimentalForeignApi::class)
 @Composable
 actual fun CameraPreview(modifier: Modifier, onPreviewReady: () -> Unit) {
-    LaunchedEffect(Unit) { onPreviewReady() }
-    Box(modifier.fillMaxSize()) {
-        Text("Camera preview not available on iOS yet", modifier = Modifier)
+    val repository = koinInject<QrScannerRepository>() as IosQrScannerRepository
+    val previewLayer = remember {
+        AVCaptureVideoPreviewLayer(session = repository.session).apply {
+            videoGravity = AVLayerVideoGravityResizeAspectFill
+        }
     }
+    UIKitView(
+        factory = {
+            UIView().apply { layer.addSublayer(previewLayer) }
+        },
+        update = { view ->
+            previewLayer.setFrame(view.bounds)
+        },
+        modifier = modifier
+    )
+    LaunchedEffect(Unit) { onPreviewReady() }
 }
 


### PR DESCRIPTION
## Summary
- implement iOS QR scanner camera preview using AVCaptureVideoPreviewLayer
- expose shared AVCaptureSession in repository for preview and scanning

## Testing
- `./gradlew :composeApp:build -x test` *(fails: SDK location not found)*
- `./gradlew ktlintCheck detekt` *(fails: Task 'ktlintCheck' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c46ea7bc83279128e1665724df48